### PR TITLE
Improve graphics and animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Ein einfaches 2D-Browserspiel in HTML5 und JavaScript. Das U-Boot bleibt dabei in der Bildschirmmitte, Zombieboote nähern sich von außen. Ziel ist es, möglichst viele Wellen zu überstehen.
 
+Die aktuelle Version bietet verbesserte Grafiken mit detailreich gezeichneten Booten und animierten Effekten.
+
 ## Starten
 
 Öffne `index.html` in einem Browser. Es werden keine externen Bibliotheken benötigt.


### PR DESCRIPTION
## Summary
- add more detailed ship, torpedo and zombie boat rendering
- implement bubble and explosion effects for actions
- update update & draw loops to include new effects and gradient sea background
- mention new animations in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f4a90fbd48333bfb2c34a8aa20022